### PR TITLE
Change preprocessing pipeline for torchtext 0.13. Field has been deprecated.

### DIFF
--- a/1 - Sequence to Sequence Learning with Neural Networks.ipynb
+++ b/1 - Sequence to Sequence Learning with Neural Networks.ipynb
@@ -2,7 +2,11 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# 1 - Sequence to Sequence Learning with Neural Networks\n",
     "\n",
@@ -50,15 +54,21 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import torch\n",
     "import torch.nn as nn\n",
     "import torch.optim as optim\n",
     "\n",
-    "from torchtext.legacy.datasets import Multi30k\n",
-    "from torchtext.legacy.data import Field, BucketIterator\n",
+    "from torchtext.data import get_tokenizer\n",
+    "from torchtext.vocab import build_vocab_from_iterator\n",
+    "from torchtext.datasets import Multi30k\n",
+    "\n",
     "\n",
     "import spacy\n",
     "import numpy as np\n",
@@ -70,7 +80,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We'll set the random seeds for deterministic results."
    ]
@@ -78,7 +92,11 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "SEED = 1234\n",
@@ -92,7 +110,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Next, we'll create the tokenizers. A tokenizer is used to turn a string containing a sentence into a list of individual tokens that make up that string, e.g. \"good morning!\" becomes [\"good\", \"morning\", \"!\"]. We'll start talking about the sentences being a sequence of tokens from now, instead of saying they're a sequence of words. What's the difference? Well, \"good\" and \"morning\" are both words and tokens, but \"!\" is a token, not a word. \n",
     "\n",
@@ -110,7 +132,11 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "spacy_de = spacy.load('de_core_news_sm')\n",
@@ -119,7 +145,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Next, we create the tokenizer functions. These can be passed to torchtext and will take in the sentence as a string and return the sentence as a list of tokens.\n",
     "\n",
@@ -129,98 +159,199 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def tokenize_de(text):\n",
     "    \"\"\"\n",
     "    Tokenizes German text from a string into a list of strings (tokens) and reverses it\n",
     "    \"\"\"\n",
-    "    return [tok.text for tok in spacy_de.tokenizer(text)][::-1]\n",
+    "    return [tok.text.lower() for tok in spacy_de.tokenizer(text)][::-1]\n",
     "\n",
     "def tokenize_en(text):\n",
     "    \"\"\"\n",
     "    Tokenizes English text from a string into a list of strings (tokens)\n",
     "    \"\"\"\n",
-    "    return [tok.text for tok in spacy_en.tokenizer(text)]"
+    "    return [tok.text.lower() for tok in spacy_en.tokenizer(text)]"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "torchtext's `Field`s handle how data should be processed. All of the possible arguments are detailed [here](https://github.com/pytorch/text/blob/master/torchtext/data/field.py#L61). \n",
+    "Tokenizer function has been changed. The tokenizer function handle how data should be processed.[here](https://pytorch.org/text/stable/data_utils.html).\n",
     "\n",
-    "We set the `tokenize` argument to the correct tokenization function for each, with German being the `SRC` (source) field and English being the `TRG` (target) field. The field also appends the \"start of sequence\" and \"end of sequence\" tokens via the `init_token` and `eos_token` arguments, and converts all words to lowercase."
-   ]
+    "We set the `argument` in `get_tokenizer` to the correct tokenization function for each. The tokenizer will not append the \"start of sequence\" and \"end of sequence\" tokens anymore. We also need to manually converts all words to lowercase."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SRC_tokenizer = get_tokenizer(tokenize_de)\n",
+    "TRG_tokenizer = get_tokenizer(tokenize_en)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Special symbols are symbols with unique meaning. Since the tokenizer will not append the \"start of sequence\" and \"end of sequence\". We will need to manually add them in building vocab. Yield_tokens is the help function to split string into words (tokens)."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [],
+   "source": [
+    "special_symbols = ['<unk>', '<pad>' ,'<sos>', '<eos>']\n",
+    "\n",
+    "def yield_tokens(dataset, tokenizer, is_source):\n",
+    "    for i in dataset:\n",
+    "        if is_source:\n",
+    "            yield tokenizer(i[0])\n",
+    "        else:\n",
+    "            yield tokenizer(i[1])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "Next, we’ll build the vocabulary for the source and target languages. The vocabulary is used to associate each unique token with an index (an integer). The vocabularies of the source and target languages are distinct.\n",
+    "Using the `min_freq` argument, we only allow tokens that appear at least 2 times to appear in our vocabulary. Tokens that appear only once are converted into an `<unk>` (unknown) token. `specials` are symbols having unique meanings such as unknown token, beginning of sentence token, etc... ` special_first` appends special symbols at the beginning\n",
+    "\n",
+    "Default_index is returned when the token is not in vocabulary. Set `<unk>` token index to default index to convert words that appear once into `<unk>` token\n",
+    "\n",
+    "It is important to note that our vocabulary should only be built from the training set and not the validation/test set. This prevents “information leakage” into our model, giving us artifically inflated validation/test scores."
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [],
+   "source": [
+    "train_set = Multi30k(split='train', language_pair=('de', 'en'))\n",
+    "SRC_vocab_transform = build_vocab_from_iterator(yield_tokens(train_set, SRC_tokenizer, True), min_freq = 2, specials = special_symbols, special_first = True)\n",
+    "#Reset train set\n",
+    "train_set = Multi30k(split='train', language_pair=('de', 'en'))\n",
+    "TRG_vocab_transform = build_vocab_from_iterator(yield_tokens(train_set, TRG_tokenizer, False), min_freq = 2, specials = special_symbols, special_first = True)\n",
+    "\n",
+    "\n",
+    "\n",
+    "SRC_vocab_transform.set_default_index(SRC_vocab_transform['<unk>'])\n",
+    "TRG_vocab_transform.set_default_index(TRG_vocab_transform['<unk>'])"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/home/ben/miniconda3/envs/pytorch17/lib/python3.8/site-packages/torchtext-0.9.0a0+c38fd42-py3.8-linux-x86_64.egg/torchtext/data/field.py:150: UserWarning: Field class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
+      "Unique tokens in source (de) vocabulary: 7854\n",
+      "Unique tokens in target (en) vocabulary: 5894\n"
      ]
     }
    ],
    "source": [
-    "SRC = Field(tokenize = tokenize_de, \n",
-    "            init_token = '<sos>', \n",
-    "            eos_token = '<eos>', \n",
-    "            lower = True)\n",
-    "\n",
-    "TRG = Field(tokenize = tokenize_en, \n",
-    "            init_token = '<sos>', \n",
-    "            eos_token = '<eos>', \n",
-    "            lower = True)"
-   ]
+    "print(f\"Unique tokens in source (de) vocabulary: {len(SRC_vocab_transform)}\")\n",
+    "print(f\"Unique tokens in target (en) vocabulary: {len(TRG_vocab_transform)}\")"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Next, we download and load the train, validation and test data. \n",
     "\n",
     "The dataset we'll be using is the [Multi30k dataset](https://github.com/multi30k/dataset). This is a dataset with ~30,000 parallel English, German and French sentences, each with ~12 words per sentence. \n",
     "\n",
-    "`exts` specifies which languages to use as the source and target (source goes first) and `fields` specifies which field to use for the source and target."
+    "`language_pair` specifies which languages to use as the source and target (source goes first)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ben/miniconda3/envs/pytorch17/lib/python3.8/site-packages/torchtext-0.9.0a0+c38fd42-py3.8-linux-x86_64.egg/torchtext/data/example.py:78: UserWarning: Example class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('Example class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.', UserWarning)\n"
-     ]
+   "execution_count": 9,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
     }
-   ],
+   },
+   "outputs": [],
    "source": [
-    "train_data, valid_data, test_data = Multi30k.splits(exts = ('.de', '.en'), \n",
-    "                                                    fields = (SRC, TRG))"
+    "train_data, valid_data, test_data = Multi30k(split=('train','valid','test'), language_pair=('de', 'en'))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We can double check that we've loaded the right number of examples:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 10,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -233,94 +364,68 @@
     }
    ],
    "source": [
-    "print(f\"Number of training examples: {len(train_data.examples)}\")\n",
-    "print(f\"Number of validation examples: {len(valid_data.examples)}\")\n",
-    "print(f\"Number of testing examples: {len(test_data.examples)}\")"
+    "print(f\"Number of training examples: {len(train_data)}\")\n",
+    "print(f\"Number of validation examples: {len(valid_data)}\")\n",
+    "print(f\"Number of testing examples: {len(test_data)}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can also print out an example, making sure the source sentence is reversed:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'src': ['.', 'büsche', 'vieler', 'nähe', 'der', 'in', 'freien', 'im', 'sind', 'männer', 'weiße', 'junge', 'zwei'], 'trg': ['two', 'young', ',', 'white', 'males', 'are', 'outside', 'near', 'many', 'bushes', '.']}\n"
-     ]
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
     }
-   ],
+   },
    "source": [
-    "print(vars(train_data.examples[0]))"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The period is at the beginning of the German (src) sentence, so it looks like the sentence has been correctly reversed.\n",
-    "\n",
-    "Next, we'll build the *vocabulary* for the source and target languages. The vocabulary is used to associate each unique token with an index (an integer). The vocabularies of the source and target languages are distinct.\n",
-    "\n",
-    "Using the `min_freq` argument, we only allow tokens that appear at least 2 times to appear in our vocabulary. Tokens that appear only once are converted into an `<unk>` (unknown) token.\n",
-    "\n",
-    "It is important to note that our vocabulary should only be built from the training set and not the validation/test set. This prevents \"information leakage\" into our model, giving us artifically inflated validation/test scores."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "SRC.build_vocab(train_data, min_freq = 2)\n",
-    "TRG.build_vocab(train_data, min_freq = 2)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Unique tokens in source (de) vocabulary: 7853\n",
-      "Unique tokens in target (en) vocabulary: 5893\n"
-     ]
-    }
-   ],
-   "source": [
-    "print(f\"Unique tokens in source (de) vocabulary: {len(SRC.vocab)}\")\n",
-    "print(f\"Unique tokens in target (en) vocabulary: {len(TRG.vocab)}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The final step of preparing the data is to create the iterators. These can be iterated on to return a batch of data which will have a `src` attribute (the PyTorch tensors containing a batch of numericalized source sentences) and a `trg` attribute (the PyTorch tensors containing a batch of numericalized target sentences). Numericalized is just a fancy way of saying they have been converted from a sequence of readable tokens to a sequence of corresponding indexes, using the vocabulary. \n",
-    "\n",
-    "We also need to define a `torch.device`. This is used to tell torchText to put the tensors on the GPU or not. We use the `torch.cuda.is_available()` function, which will return `True` if a GPU is detected on our computer. We pass this `device` to the iterator.\n",
-    "\n",
-    "When we get a batch of examples using an iterator we need to make sure that all of the source sentences are padded to the same length, the same with the target sentences. Luckily, torchText iterators handle this for us! \n",
-    "\n",
-    "We use a `BucketIterator` instead of the standard `Iterator` as it creates batches in such a way that it minimizes the amount of padding in both the source and target sentences. "
+    "We can also print out an example. It is one of the original sentence pairs from the dataset."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('Zwei junge weiße Männer sind im Freien in der Nähe vieler Büsche.\\n', 'Two young, White males are outside near many bushes.\\n')\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(list(train_data)[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
+   "source": [
+    "The final step of preparing the data is to create the iterators. These can be iterated on to return a batch of data which will have a `src` attribute (the PyTorch tensors containing a batch of numericalized source sentences) and a `trg` attribute (the PyTorch tensors containing a batch of numericalized target sentences). Numericalized is just a fancy way of saying they have been converted from a sequence of readable tokens to a sequence of corresponding indexes, using the vocabulary. \n",
+    "\n",
+    "We also need to define a `torch.device`. This is used to tell torchText to put the tensors on the GPU or not. We use the `torch.cuda.is_available()` function, which will return `True` if a GPU is detected on our computer. We pass this `device` to the iterator.\n",
+    "\n",
+    "When we get a batch of examples using an iterator we need to make sure that all of the source sentences are padded to the same length, the same with the target sentences. New version of torchtext is not handling this for us. This will be done via `pad_sequence` function in `torch.nn.utils.rnn` module.\n",
+    "\n",
+    "`DataLoader` in `torch.utils.data` has replaced BucketIterator. Working in conjunction with `collate_fn`, whenever dataloader has created a batch, it will call `collate_fn(batch)`. By implementing `pad_sequence` in `collate_fn`, we will minimize the amount of padding in both the source and target sentences as each batch will have different paddings according to their max sentence length. In addition, we will also reverse sentence and transform sentence into indexes with `<sos>` and `<eos>` token in `collate_fn`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')"
@@ -328,30 +433,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ben/miniconda3/envs/pytorch17/lib/python3.8/site-packages/torchtext-0.9.0a0+c38fd42-py3.8-linux-x86_64.egg/torchtext/data/iterator.py:48: UserWarning: BucketIterator class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
-     ]
-    }
+   "execution_count": 13,
+   "outputs": [],
+   "source": [
+    "from torch.utils.data import DataLoader\n",
+    "from torch.nn.utils.rnn import pad_sequence\n",
+    "#function to add '<sos>' and '<eos>'\n",
+    "def add_symbols(sentence, transform):\n",
+    "    sos = torch.tensor([transform['<sos>']])\n",
+    "    eos = torch.tensor([transform['<eos>']])\n",
+    "    return torch.cat((sos,sentence,eos))\n",
+    "def collate_fn(batch):\n",
+    "    src_batch = []\n",
+    "    trg_batch = []\n",
+    "    src_len = []\n",
+    "    for src, trg in batch:\n",
+    "        #split sentence into tokens\n",
+    "        src_tensor = SRC_tokenizer(src.rstrip(\"\\n\"))\n",
+    "        trg_tensor = SRC_tokenizer(trg.rstrip(\"\\n\"))\n",
+    "        #convert tokens to index and to tensor and add <sos> and <eos> to each sentence\n",
+    "        src_tensor = add_symbols(torch.tensor(SRC_vocab_transform(src_tensor)), SRC_vocab_transform)\n",
+    "        trg_tensor = add_symbols(torch.tensor(TRG_vocab_transform(trg_tensor)), TRG_vocab_transform)\n",
+    "        src_batch.append(src_tensor)\n",
+    "        #track length of each source sentence, not useful in this model. Will be useful in further models\n",
+    "        src_len.append(len(src_tensor))\n",
+    "        trg_batch.append(trg_tensor)\n",
+    "    src_len = torch.tensor(src_len, dtype = torch.int)\n",
+    "    src_batch = pad_sequence(src_batch, padding_value=SRC_vocab_transform['<pad>'])\n",
+    "    trg_batch = pad_sequence(trg_batch, padding_value=SRC_vocab_transform['<pad>'])\n",
+    "    src_len, idx = torch.sort(src_len,descending=True)\n",
+    "    #src_len is not useful in this model\n",
+    "    return src_batch, src_len, trg_batch"
    ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
    "source": [
     "BATCH_SIZE = 128\n",
     "\n",
-    "train_iterator, valid_iterator, test_iterator = BucketIterator.splits(\n",
-    "    (train_data, valid_data, test_data), \n",
-    "    batch_size = BATCH_SIZE, \n",
-    "    device = device)"
+    "train_set, valid_set = Multi30k(split=('train','valid'), language_pair=('de', 'en'))\n",
+    "train_dataloader = DataLoader(train_set, batch_size=BATCH_SIZE, collate_fn=collate_fn)\n",
+    "valid_dataloader = DataLoader(valid_set, batch_size=BATCH_SIZE, collate_fn=collate_fn)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Building the Seq2Seq Model\n",
     "\n",
@@ -417,8 +561,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "class Encoder(nn.Module):\n",
@@ -455,7 +603,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Decoder\n",
     "\n",
@@ -485,8 +637,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {},
+   "execution_count": 16,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "class Decoder(nn.Module):\n",
@@ -543,7 +699,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Seq2Seq\n",
     "\n",
@@ -595,8 +755,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {},
+   "execution_count": 17,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "class Seq2Seq(nn.Module):\n",
@@ -656,7 +820,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Training the Seq2Seq Model\n",
     "\n",
@@ -669,12 +837,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {},
+   "execution_count": 18,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
-    "INPUT_DIM = len(SRC.vocab)\n",
-    "OUTPUT_DIM = len(TRG.vocab)\n",
+    "device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')\n",
+    "INPUT_DIM = len(SRC_vocab_transform)\n",
+    "OUTPUT_DIM = len(TRG_vocab_transform)\n",
     "ENC_EMB_DIM = 256\n",
     "DEC_EMB_DIM = 256\n",
     "HID_DIM = 512\n",
@@ -690,7 +863,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Next up is initializing the weights of our model. In the paper they state they initialize all weights from a uniform distribution between -0.08 and +0.08, i.e. $\\mathcal{U}(-0.08, 0.08)$.\n",
     "\n",
@@ -699,28 +876,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
-   "metadata": {},
+   "execution_count": 19,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": [
-       "Seq2Seq(\n",
-       "  (encoder): Encoder(\n",
-       "    (embedding): Embedding(7853, 256)\n",
-       "    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n",
-       "    (dropout): Dropout(p=0.5, inplace=False)\n",
-       "  )\n",
-       "  (decoder): Decoder(\n",
-       "    (embedding): Embedding(5893, 256)\n",
-       "    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n",
-       "    (fc_out): Linear(in_features=512, out_features=5893, bias=True)\n",
-       "    (dropout): Dropout(p=0.5, inplace=False)\n",
-       "  )\n",
-       ")"
-      ]
+      "text/plain": "Seq2Seq(\n  (encoder): Encoder(\n    (embedding): Embedding(7854, 256)\n    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n    (dropout): Dropout(p=0.5, inplace=False)\n  )\n  (decoder): Decoder(\n    (embedding): Embedding(5894, 256)\n    (rnn): LSTM(256, 512, num_layers=2, dropout=0.5)\n    (fc_out): Linear(in_features=512, out_features=5894, bias=True)\n    (dropout): Dropout(p=0.5, inplace=False)\n  )\n)"
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -735,21 +902,29 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We also define a function that will calculate the number of trainable parameters in the model."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
-   "metadata": {},
+   "execution_count": 20,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The model has 13,898,501 trainable parameters\n"
+      "The model has 13,899,526 trainable parameters\n"
      ]
     }
    ],
@@ -762,15 +937,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We define our optimizer, which we use to update our parameters in the training loop. Check out [this](http://ruder.io/optimizing-gradient-descent/) post for information about different optimizers. Here, we'll use Adam."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
-   "metadata": {},
+   "execution_count": 21,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "optimizer = optim.Adam(model.parameters())"
@@ -778,7 +961,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Next, we define our loss function. The `CrossEntropyLoss` function calculates both the log softmax as well as the negative log-likelihood of our predictions. \n",
     "\n",
@@ -787,20 +974,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
-   "metadata": {},
+   "execution_count": 22,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
-    "TRG_PAD_IDX = TRG.vocab.stoi[TRG.pad_token]\n",
-    "\n",
+    "TRG_PAD_IDX = TRG_vocab_transform['<pad>']\n",
     "criterion = nn.CrossEntropyLoss(ignore_index = TRG_PAD_IDX)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
-    "Next, we'll define our training loop. \n",
+    "Next, we'll define our training loop.\n",
     "\n",
     "First, we'll set the model into \"training mode\" with `model.train()`. This will turn on dropout (and batch normalization, which we aren't using) and then iterate through our data iterator.\n",
     "\n",
@@ -834,8 +1028,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
-   "metadata": {},
+   "execution_count": 23,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def train(model, iterator, optimizer, criterion, clip):\n",
@@ -844,10 +1042,10 @@
     "    \n",
     "    epoch_loss = 0\n",
     "    \n",
-    "    for i, batch in enumerate(iterator):\n",
+    "    for src, _, trg in iterator:\n",
     "        \n",
-    "        src = batch.src\n",
-    "        trg = batch.trg\n",
+    "        src = src.to(device)\n",
+    "        trg = trg.to(device)\n",
     "        \n",
     "        optimizer.zero_grad()\n",
     "        \n",
@@ -879,7 +1077,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Our evaluation loop is similar to our training loop, however as we aren't updating any parameters we don't need to pass an optimizer or a clip value.\n",
     "\n",
@@ -892,8 +1094,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "metadata": {},
+   "execution_count": 24,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def evaluate(model, iterator, criterion):\n",
@@ -904,10 +1110,10 @@
     "    \n",
     "    with torch.no_grad():\n",
     "    \n",
-    "        for i, batch in enumerate(iterator):\n",
+    "        for src, _, trg in iterator:\n",
     "\n",
-    "            src = batch.src\n",
-    "            trg = batch.trg\n",
+    "            src = src.to(device)\n",
+    "            trg = trg.to(device)\n",
     "\n",
     "            output = model(src, trg, 0) #turn off teacher forcing\n",
     "\n",
@@ -931,15 +1137,23 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Next, we'll create a function that we'll use to tell us how long an epoch takes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "metadata": {},
+   "execution_count": 25,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "def epoch_time(start_time, end_time):\n",
@@ -951,7 +1165,11 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We can finally start training our model!\n",
     "\n",
@@ -962,51 +1180,47 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
-   "metadata": {},
+   "execution_count": 26,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/home/ben/miniconda3/envs/pytorch17/lib/python3.8/site-packages/torchtext-0.9.0a0+c38fd42-py3.8-linux-x86_64.egg/torchtext/data/batch.py:23: UserWarning: Batch class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.\n",
-      "  warnings.warn('{} class will be retired soon and moved to torchtext.legacy. Please see the most recent release notes for further information.'.format(self.__class__.__name__), UserWarning)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Epoch: 01 | Time: 0m 26s\n",
-      "\tTrain Loss: 5.052 | Train PPL: 156.386\n",
-      "\t Val. Loss: 4.916 |  Val. PPL: 136.446\n",
-      "Epoch: 02 | Time: 0m 26s\n",
-      "\tTrain Loss: 4.483 | Train PPL:  88.521\n",
-      "\t Val. Loss: 4.789 |  Val. PPL: 120.154\n",
-      "Epoch: 03 | Time: 0m 25s\n",
-      "\tTrain Loss: 4.195 | Train PPL:  66.363\n",
-      "\t Val. Loss: 4.552 |  Val. PPL:  94.854\n",
-      "Epoch: 04 | Time: 0m 25s\n",
-      "\tTrain Loss: 3.963 | Train PPL:  52.625\n",
-      "\t Val. Loss: 4.485 |  Val. PPL:  88.672\n",
-      "Epoch: 05 | Time: 0m 25s\n",
-      "\tTrain Loss: 3.783 | Train PPL:  43.955\n",
-      "\t Val. Loss: 4.375 |  Val. PPL:  79.466\n",
-      "Epoch: 06 | Time: 0m 25s\n",
-      "\tTrain Loss: 3.636 | Train PPL:  37.957\n",
-      "\t Val. Loss: 4.234 |  Val. PPL:  69.011\n",
-      "Epoch: 07 | Time: 0m 26s\n",
-      "\tTrain Loss: 3.506 | Train PPL:  33.329\n",
-      "\t Val. Loss: 4.077 |  Val. PPL:  58.948\n",
-      "Epoch: 08 | Time: 0m 27s\n",
-      "\tTrain Loss: 3.370 | Train PPL:  29.090\n",
-      "\t Val. Loss: 4.018 |  Val. PPL:  55.581\n",
-      "Epoch: 09 | Time: 0m 26s\n",
-      "\tTrain Loss: 3.241 | Train PPL:  25.569\n",
-      "\t Val. Loss: 3.934 |  Val. PPL:  51.113\n",
-      "Epoch: 10 | Time: 0m 26s\n",
-      "\tTrain Loss: 3.157 | Train PPL:  23.492\n",
-      "\t Val. Loss: 3.927 |  Val. PPL:  50.743\n"
+      "Epoch: 01 | Time: 0m 31s\n",
+      "\tTrain Loss: 4.956 | Train PPL: 141.992\n",
+      "\t Val. Loss: 4.917 |  Val. PPL: 136.574\n",
+      "Epoch: 02 | Time: 0m 28s\n",
+      "\tTrain Loss: 4.479 | Train PPL:  88.187\n",
+      "\t Val. Loss: 4.841 |  Val. PPL: 126.599\n",
+      "Epoch: 03 | Time: 0m 29s\n",
+      "\tTrain Loss: 4.260 | Train PPL:  70.795\n",
+      "\t Val. Loss: 4.739 |  Val. PPL: 114.320\n",
+      "Epoch: 04 | Time: 0m 28s\n",
+      "\tTrain Loss: 4.085 | Train PPL:  59.416\n",
+      "\t Val. Loss: 4.570 |  Val. PPL:  96.542\n",
+      "Epoch: 05 | Time: 0m 29s\n",
+      "\tTrain Loss: 3.834 | Train PPL:  46.233\n",
+      "\t Val. Loss: 4.508 |  Val. PPL:  90.716\n",
+      "Epoch: 06 | Time: 0m 29s\n",
+      "\tTrain Loss: 3.636 | Train PPL:  37.933\n",
+      "\t Val. Loss: 4.284 |  Val. PPL:  72.534\n",
+      "Epoch: 07 | Time: 0m 29s\n",
+      "\tTrain Loss: 3.437 | Train PPL:  31.101\n",
+      "\t Val. Loss: 4.125 |  Val. PPL:  61.843\n",
+      "Epoch: 08 | Time: 0m 29s\n",
+      "\tTrain Loss: 3.251 | Train PPL:  25.812\n",
+      "\t Val. Loss: 4.023 |  Val. PPL:  55.862\n",
+      "Epoch: 09 | Time: 0m 30s\n",
+      "\tTrain Loss: 3.110 | Train PPL:  22.412\n",
+      "\t Val. Loss: 3.947 |  Val. PPL:  51.778\n",
+      "Epoch: 10 | Time: 0m 29s\n",
+      "\tTrain Loss: 2.952 | Train PPL:  19.135\n",
+      "\t Val. Loss: 3.875 |  Val. PPL:  48.180\n"
      ]
     }
    ],
@@ -1017,11 +1231,14 @@
     "best_valid_loss = float('inf')\n",
     "\n",
     "for epoch in range(N_EPOCHS):\n",
-    "    \n",
+    "    BATCH_SIZE = 128\n",
+    "    train_set, valid_set = Multi30k(split=('train','valid'), language_pair=('de', 'en'))\n",
+    "    train_dataloader = DataLoader(train_set, batch_size=BATCH_SIZE, collate_fn=collate_fn)\n",
+    "    valid_dataloader = DataLoader(valid_set, batch_size=BATCH_SIZE, collate_fn=collate_fn)\n",
     "    start_time = time.time()\n",
     "    \n",
-    "    train_loss = train(model, train_iterator, optimizer, criterion, CLIP)\n",
-    "    valid_loss = evaluate(model, valid_iterator, criterion)\n",
+    "    train_loss = train(model, train_dataloader, optimizer, criterion, CLIP)\n",
+    "    valid_loss = evaluate(model, valid_dataloader, criterion)\n",
     "    \n",
     "    end_time = time.time()\n",
     "    \n",
@@ -1038,35 +1255,48 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We'll load the parameters (`state_dict`) that gave our model the best validation loss and run it the model on the test set."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
-   "metadata": {},
+   "execution_count": 27,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "| Test Loss: 3.951 | Test PPL:  52.001 |\n"
+      "| Test Loss: 3.890 | Test PPL:  48.897 |\n"
      ]
     }
    ],
    "source": [
     "model.load_state_dict(torch.load('tut1-model.pt'))\n",
-    "\n",
-    "test_loss = evaluate(model, test_iterator, criterion)\n",
+    "test_set = Multi30k(split=('test'), language_pair=('de', 'en'))\n",
+    "test_dataloader = DataLoader(test_set, batch_size=BATCH_SIZE, collate_fn=collate_fn)\n",
+    "test_loss = evaluate(model, test_dataloader, criterion)\n",
     "\n",
     "print(f'| Test Loss: {test_loss:.3f} | Test PPL: {math.exp(test_loss):7.3f} |')"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In the following notebook we'll implement a model that achieves improved test perplexity, but only uses a single layer in the encoder and the decoder."
    ]


### PR DESCRIPTION
Thank you for providing such a detailed tutorial. 
I updated the preprocessing pipeline for torchtext 0.13 by replacing Field and BucketIterator with get_tokenizer and Dataloader according to the official torchtext migration guideline. Code has been tested locally. The training results differ slightly from the original one because padding token is now part of vocabulary which increases the number of parameters in the embedding layer.
I updated for the first tutorial for now. If you think it will be helpful, I will update the rest.
